### PR TITLE
disable automatic code signing

### DIFF
--- a/CRFModuleValidation.xcodeproj/project.pbxproj
+++ b/CRFModuleValidation.xcodeproj/project.pbxproj
@@ -353,7 +353,7 @@
 					60F7A1421E89C76E00B123FA = {
 						CreatedOnToolsVersion = 8.2.1;
 						DevelopmentTeam = KA9Z8R6M6K;
-						ProvisioningStyle = Automatic;
+						ProvisioningStyle = Manual;
 						TestTargetID = 60F7A12E1E89C76E00B123FA;
 					};
 				};
@@ -688,6 +688,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = org.sagebase.CRFModuleValidationTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "CRFModuleValidationTests/Bridging-Header.h";
 				SWIFT_VERSION = 3.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/CRFModuleValidation.app/CRFModuleValidation";
@@ -699,6 +700,7 @@
 			buildSettings = {
 				ALWAYS_EMBED_SWIFT_STANDARD_LIBRARIES = YES;
 				BUNDLE_LOADER = "$(TEST_HOST)";
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
 				DEVELOPMENT_TEAM = KA9Z8R6M6K;
 				FRAMEWORK_SEARCH_PATHS = (
 					"$(inherited)",
@@ -708,6 +710,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = org.sagebase.CRFModuleValidationTests;
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				PROVISIONING_PROFILE_SPECIFIER = "";
 				SWIFT_OBJC_BRIDGING_HEADER = "CRFModuleValidationTests/Bridging-Header.h";
 				SWIFT_VERSION = 3.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/CRFModuleValidation.app/CRFModuleValidation";


### PR DESCRIPTION
Getting this error message on travis build:
 Code signing is required for product type 'Application' in SDK 'iOS 10.2

Which indicates that automatic code signing is turned on.  Make sure
it's off so we don't get that error.