### PR TITLE
increase travis build timeout

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ install:
 - gem install bundler
 - bundle install
 script:
-- travis_wait 60 ./travis/build.sh
+- travis_wait 75 ./travis/build.sh
 branches:
   only:
   - master


### PR DESCRIPTION
Builds to test flight is timing out.  Try increasing it another 15 mins.