### PR TITLE
fix Fitbit connection

### DIFF
--- a/CRFModuleValidation.xcodeproj/project.pbxproj
+++ b/CRFModuleValidation.xcodeproj/project.pbxproj
@@ -20,6 +20,7 @@
 		60F7A2161E89D0B200B123FA /* BridgeSDK.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 60F7A2141E89D0B200B123FA /* BridgeSDK.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
 		60F7A2171E89D0B200B123FA /* BridgeAppSDK.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 60F7A2071E89D01100B123FA /* BridgeAppSDK.framework */; };
 		60F7A2181E89D0B200B123FA /* BridgeAppSDK.framework in Embed Frameworks */ = {isa = PBXBuildFile; fileRef = 60F7A2071E89D01100B123FA /* BridgeAppSDK.framework */; settings = {ATTRIBUTES = (CodeSignOnCopy, RemoveHeadersOnCopy, ); }; };
+		80B3FB531FB51EC900B81B6E /* FitbitStep.swift in Sources */ = {isa = PBXBuildFile; fileRef = 80B3FB4C1FB51EC900B81B6E /* FitbitStep.swift */; };
 		FF1CC78A1FB3D20100EF03A1 /* CRFHeartRateStepViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF1CC7891FB3D20100EF03A1 /* CRFHeartRateStepViewController.swift */; };
 		FF237EBE1FA9248D007E8A5F /* CRFTaskFactory.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF237EBD1FA9248D007E8A5F /* CRFTaskFactory.swift */; };
 		FF2A1D571FB174570095044A /* CRFHeartRateRecorder.swift in Sources */ = {isa = PBXBuildFile; fileRef = FF2A1D561FB174570095044A /* CRFHeartRateRecorder.swift */; };
@@ -182,6 +183,7 @@
 		60F7A20E1E89D0B200B123FA /* ResearchKit.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = ResearchKit.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		60F7A2111E89D0B200B123FA /* ResearchUXFactory.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = ResearchUXFactory.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		60F7A2141E89D0B200B123FA /* BridgeSDK.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; path = BridgeSDK.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		80B3FB4C1FB51EC900B81B6E /* FitbitStep.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = FitbitStep.swift; sourceTree = "<group>"; };
 		FF1CC7891FB3D20100EF03A1 /* CRFHeartRateStepViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CRFHeartRateStepViewController.swift; sourceTree = "<group>"; };
 		FF237EBD1FA9248D007E8A5F /* CRFTaskFactory.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CRFTaskFactory.swift; sourceTree = "<group>"; };
 		FF2A1D561FB174570095044A /* CRFHeartRateRecorder.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CRFHeartRateRecorder.swift; sourceTree = "<group>"; };
@@ -270,6 +272,7 @@
 				FFA607B01F7080F80034A4C0 /* ScheduledActivityManager.swift */,
 				FF7752371F7093AF004925B8 /* SurveyFactory.swift */,
 				FF7752451F709D5D004925B8 /* StudyOverviewViewController.swift */,
+				80B3FB4C1FB51EC900B81B6E /* FitbitStep.swift */,
 				FF55C41E1FAAEB3D004EDB59 /* TaskIntroductionStepViewController.swift */,
 				FF9D7F591FA8DEB8008506DB /* Step Customization */,
 				60F7A1641E89C98800B123FA /* Resources */,
@@ -704,6 +707,7 @@
 				FF7752461F709D5D004925B8 /* StudyOverviewViewController.swift in Sources */,
 				FF7752861F722CB4004925B8 /* UIColor+BridgeMapping.swift in Sources */,
 				FFDD77F81FAD30900024BDD1 /* CRFRunDistanceStepViewController.swift in Sources */,
+				80B3FB531FB51EC900B81B6E /* FitbitStep.swift in Sources */,
 				FF1CC78A1FB3D20100EF03A1 /* CRFHeartRateStepViewController.swift in Sources */,
 				FFA607971F7074FB0034A4C0 /* AppDelegate.swift in Sources */,
 				FF2A1D571FB174570095044A /* CRFHeartRateRecorder.swift in Sources */,

--- a/CRFModuleValidation/Assets.xcassets/fitbitLogo.imageset/Contents.json
+++ b/CRFModuleValidation/Assets.xcassets/fitbitLogo.imageset/Contents.json
@@ -10,6 +10,7 @@
     "author" : "xcode"
   },
   "properties" : {
+    "template-rendering-intent" : "original",
     "preserves-vector-representation" : true
   }
 }

--- a/CRFModuleValidation/FitbitStep.swift
+++ b/CRFModuleValidation/FitbitStep.swift
@@ -1,0 +1,142 @@
+//
+//  FitbitStep.swift
+//  CRFModuleValidation
+//
+//  Copyright © 2017 Sage Bionetworks. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without modification,
+// are permitted provided that the following conditions are met:
+//
+// 1.  Redistributions of source code must retain the above copyright notice, this
+// list of conditions and the following disclaimer.
+//
+// 2.  Redistributions in binary form must reproduce the above copyright notice,
+// this list of conditions and the following disclaimer in the documentation and/or
+// other materials provided with the distribution.
+//
+// 3.  Neither the name of the copyright holder(s) nor the names of any contributors
+// may be used to endorse or promote products derived from this software without
+// specific prior written permission. No license is granted to the trademarks of
+// the copyright holders even if such marks are included in this software.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+// AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+// ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT OWNER OR CONTRIBUTORS BE LIABLE
+// FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+// DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+// SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+// CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+// OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+//
+
+import BridgeAppSDK
+
+open class FitbitSkipRule: ORKSkipStepNavigationRule {
+    
+    /**
+     Whether or not the rule should be applied
+     @param taskResult  Ignored.
+     @return            `YES` if Fitbit is alrady connectd
+    */
+    open override func stepShouldSkip(with taskResult: ORKTaskResult) -> Bool {
+        // TODO emm 2017-11-09 check if Fitbit is already connected
+        return false
+    }
+}
+
+open class FitbitStep: SBAInstructionStep, SBANavigationSkipRule {
+
+    override public init(identifier: String) {
+        super.init(identifier: identifier)
+        commonInit()
+    }
+    
+    public override init(inputItem: SBASurveyItem) {
+        super.init(inputItem: inputItem)
+        commonInit()
+    }
+    
+    fileprivate func commonInit() {
+        if self.title == nil {
+            // TODO emm 2017-11-09 localize
+            self.title = "Connect your Fitbit"
+        }
+    }
+    
+    required public init(coder aDecoder: NSCoder) {
+        super.init(coder: aDecoder)
+    }
+    
+    override open func stepViewControllerClass() -> AnyClass {
+        return FitbitStepViewController.classForCoder()
+    }
+
+    override open func isInstructionStep() -> Bool {
+        return true
+    }
+    
+    // MARK: SBANavigationSkipRule
+    
+    open func shouldSkipStep(with result: ORKTaskResult, and additionalTaskResults: [ORKTaskResult]?) -> Bool {
+        // TODO emm 2017-11-09 check if they've already authorized Fitbit
+        return false
+    }
+    
+}
+
+open class FitbitStepViewController: SBAInstructionStepViewController {
+    
+    var fitbitConnected: Bool = false
+    
+    override open var result: ORKStepResult? {
+        guard let result = super.result else { return nil }
+        
+        // Add a result for whether or not Fitbit was connected
+        let connectedResult = ORKBooleanQuestionResult(identifier: result.identifier)
+        connectedResult.booleanAnswer = NSNumber(value: fitbitConnected)
+        result.results = [connectedResult]
+        
+        return result
+    }
+    
+    override open func goForward() {
+        guard let fitbitStep = self.step as? FitbitStep,
+                let appDelegate = UIApplication.shared.delegate as? AppDelegate
+            else {
+                assertionFailure("Step is not of expected type")
+                super.goForward()
+                return
+        }
+        
+        // Show a loading view to indicate that something is happening
+        self.showLoadingView()
+        appDelegate.connectToFitbit(completionHandler: { [weak self] (URL, error) in
+            let connected: Bool = (URL != nil)
+            self?.hideLoadingView()
+            if connected || fitbitStep.isOptional {
+                self?.fitbitConnected = connected
+                self?.goNext()
+            }
+            else if let strongSelf = self, let strongDelegate = strongSelf.delegate {
+                let error = NSError(domain: "FitbitStepDomain", code: 1, userInfo: nil)
+                strongDelegate.stepViewControllerDidFail(strongSelf, withError: error)
+            }
+        })
+    }
+    
+    override open func skipForward() {
+        goNext()
+    }
+    
+    fileprivate func goNext() {
+        super.goForward()
+    }
+    
+    open override var cancelButtonItem: UIBarButtonItem? {
+        // Override the cancel button to *not* display. User must tap the "Continue" button.
+        get { return nil }
+        set {}
+    }
+}

--- a/CRFModuleValidation/StudyOverviewViewController.swift
+++ b/CRFModuleValidation/StudyOverviewViewController.swift
@@ -64,7 +64,7 @@ class StudyOverviewViewController: UIViewController, ORKTaskViewControllerDelega
             permission.always = true
             return permission
         }
-        let fitbitStep = SBAInstructionStep(identifier: "fitbit")
+        let fitbitStep = FitbitStep(identifier: "fitbit")
         fitbitStep.title = "Connect your Fitbit"
         fitbitStep.detailText = "Connecting to your Fitbit data allows the CRF module to understand the various aspects of your health such as your heart rate and daily movement."
         fitbitStep.continueButtonTitle = "Connect"
@@ -81,10 +81,8 @@ class StudyOverviewViewController: UIViewController, ORKTaskViewControllerDelega
     func taskViewController(_ taskViewController: ORKTaskViewController, didFinishWith reason: ORKTaskViewControllerFinishReason, error: Error?) {
         taskViewController.dismiss(animated: true) { 
             if (reason == .completed), let appDelegate = UIApplication.shared.delegate as? AppDelegate {
-                appDelegate.connectToFitbit(completionHandler: { (_, _) in
-                    // Show the appropriate view controller
-                    appDelegate.showAppropriateViewController(animated: false)
-                })
+                // Show the appropriate view controller
+                appDelegate.showAppropriateViewController(animated: false)
             }
             else {
                 // Discard the registration information that has been gathered so far


### PR DESCRIPTION
- iOS SDK 11.1 broke an important assumption in the existing logic
- Bare bones custom Fitbit step/view controller pair to look/work a little nicer and to be more flexible as to where in the onboarding flow it lives