### PR TITLE
Setup enterprise build

### DIFF
--- a/fastlane/Appfile
+++ b/fastlane/Appfile
@@ -1,7 +1,7 @@
-app_identifier "org.sagebase.crfModuleApp" # The bundle identifier of your app
+app_identifier "org.sagebase.enterprise.CRF" # The bundle identifier of your app
 apple_id "apple.developer@sagebase.org" # Your Apple email address
 
-team_id "KA9Z8R6M6K"  # Developer Portal Team ID
+team_id "4B822CZK9N"  # Developer Portal Team ID
 
 # you can even provide different app identifiers, Apple IDs and team names per lane:
 # More information: https://github.com/fastlane/fastlane/blob/master/fastlane/docs/Appfile.md

--- a/fastlane/Deliverfile
+++ b/fastlane/Deliverfile
@@ -6,5 +6,5 @@
 ###################### Automatically generated ######################
 # Feel free to remove the following line if you use fastlane (which you should)
 
-app_identifier "org.sagebase.crfModuleApp" # The bundle identifier of your app
+app_identifier "org.sagebase.enterprise.CRF" # The bundle identifier of your app
 username "apple.developer@sagebase.org" # your Apple ID user

--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -19,6 +19,10 @@ platform :ios do
   before_all do
     # ENV["SLACK_URL"] = "https://hooks.slack.com/services/..."
     ENV["MATCH_KEYCHAIN_NAME"] = "ios-build.keychain"
+    ENV["TEAM_SAGEBIO"] = "4B822CZK9N"
+    ENV["TEAM_SAGEBIO_NOT_FOR_PROFIT"] = "KA9Z8R6M6K"
+    ENV["APP_ID_ENTERPRISE"] = "org.sagebase.enterprise.CRF"
+    ENV["APP_ID"] = "org.sagebase.crfModuleApp"
   end
 
   desc "Create keychains to store certificates"
@@ -37,13 +41,37 @@ platform :ios do
   lane :certificates do |options|
     export_method = options[:export_method]
     match(
+      git_branch: ENV["TEAM_SAGEBIO_NOT_FOR_PROFIT"],
       type: "development",
+      app_identifier: ENV["APP_ID"],
+      team_id: ENV["TEAM_SAGEBIO_NOT_FOR_PROFIT"],
       keychain_name: ENV["MATCH_KEYCHAIN_NAME"],
       keychain_password: ENV["MATCH_PASSWORD"],
       readonly: true
     )
     match(
+      git_branch: ENV["TEAM_SAGEBIO"],
+      type: "development",
+      app_identifier: ENV["APP_ID_ENTERPRISE"],
+      team_id: ENV["TEAM_SAGEBIO"],
+      keychain_name: ENV["MATCH_KEYCHAIN_NAME"],
+      keychain_password: ENV["MATCH_PASSWORD"],
+      readonly: true
+    )
+    match(
+      git_branch: ENV["TEAM_SAGEBIO_NOT_FOR_PROFIT"],
       type: "appstore",
+      app_identifier: ENV["APP_ID"],
+      team_id: ENV["TEAM_SAGEBIO_NOT_FOR_PROFIT"],
+      keychain_name: ENV["MATCH_KEYCHAIN_NAME"],
+      keychain_password: ENV["MATCH_PASSWORD"],
+      readonly: true
+    )
+    match(
+      git_branch: ENV["TEAM_SAGEBIO"],
+      type: "appstore",
+      app_identifier: ENV["APP_ID_ENTERPRISE"],
+      team_id: ENV["TEAM_SAGEBIO"],
       keychain_name: ENV["MATCH_KEYCHAIN_NAME"],
       keychain_password: ENV["MATCH_PASSWORD"],
       readonly: true
@@ -87,7 +115,7 @@ platform :ios do
     commit_version_bump(xcodeproj: "#{scheme}.xcodeproj", message: "[skip ci] Version Bump")
     add_git_tag(tag: "#{version_number}_#{next_build_number}")
     push_to_git_remote(remote_branch: ENV["TRAVIS_BRANCH"])
-    testflight(ipa: "./build/#{scheme}.ipa", skip_submission: true)
+#    testflight(ipa: "./build/#{scheme}.ipa", skip_submission: true)
   end
 
   # You can define as many lanes as you want

--- a/fastlane/Matchfile
+++ b/fastlane/Matchfile
@@ -1,11 +1,11 @@
 git_url "https://github.com/Sage-Bionetworks/ios-certificates.git"
-git_branch "KA9Z8R6M6K"
+git_branch "4B822CZK9N"
 
 type "development" # The default type, can be: appstore, adhoc, enterprise or development
 
 # The bundle identifier of your app
 app_identifier [
-  "org.sagebase.crfModuleApp"]
+  "org.sagebase.enterprise.CRF"]
 
 username "apple.developer@sagebase.org" # Your Apple Developer Portal username
 

--- a/travis/build.sh
+++ b/travis/build.sh
@@ -8,10 +8,10 @@ elif [[ -z "$TRAVIS_TAG" && "$TRAVIS_BRANCH" == "master" ]]; then  # non-tag com
     # Testing is done post merge
     git clone https://github.com/Sage-Bionetworks/iOSPrivateProjectInfo.git ../iOSPrivateProjectInfo
     FASTLANE_EXPLICIT_OPEN_SIMULATOR=2 bundle exec fastlane scan
-    bundle exec fastlane ci_archive scheme:"CRFModuleValidation" export_method:"app-store"
+    bundle exec fastlane ci_archive scheme:"CRFModuleValidation" export_method:"enterprise"
 elif [[ -z "$TRAVIS_TAG" && "$TRAVIS_BRANCH" =~ ^stable-.* ]]; then # non-tag commits to stable branches
     git clone https://github.com/Sage-Bionetworks/iOSPrivateProjectInfo.git ../iOSPrivateProjectInfo
 #    FASTLANE_EXPLICIT_OPEN_SIMULATOR=2 bundle exec fastlane scan
-    bundle exec fastlane beta scheme:"CRFModuleValidation" export_method:"app-store"
+    bundle exec fastlane beta scheme:"CRFModuleValidation" export_method:"enterprise"
 fi
 exit $?


### PR DESCRIPTION
New certs and profiles were added to ios-certificates repo.
This change configures fastlane to generate enterprise builds.
It also stops deployments to testflight.