### PR TITLE
Reduce upload file sizes by only including raw motion data and downsized image.

### DIFF
--- a/CRFModuleValidation/CRFCameraStepViewController.swift
+++ b/CRFModuleValidation/CRFCameraStepViewController.swift
@@ -81,7 +81,7 @@ open class CRFCameraStepViewController: RSDStepViewController, UIImagePickerCont
 
         var url: URL?
         do {
-            if let imageData = UIImageJPEGRepresentation(chosenImage, 1.0) {
+            if let imageData = UIImageJPEGRepresentation(chosenImage, 0.5) {
                 url = try RSDFileResultUtility.createFileURL(identifier: self.step.identifier, ext: "jpeg", outputDirectory: self.taskController.taskPath.outputDirectory)
                 save(imageData, to: url!)
             }

--- a/CRFModuleValidation/CRFHeartRateStepViewController.swift
+++ b/CRFModuleValidation/CRFHeartRateStepViewController.swift
@@ -127,7 +127,7 @@ public class CRFHeartRateStepViewController: RSDActiveStepViewController, RSDAsy
         }
         
         // Create a motion recorder
-        var motionConfig = CRFMotionRecorderConfiguration(identifier: "motion", recorderTypes: [.accelerometer, .gravity, .gyro, .userAcceleration])
+        var motionConfig = CRFMotionRecorderConfiguration(identifier: "motion", recorderTypes: [.accelerometer, .gyro])
         motionConfig.stopStepIdentifier = self.step.identifier
         motionRecorder = CRFMotionRecorder(configuration: motionConfig, taskPath: taskPath, outputDirectory: taskPath.outputDirectory)
         

--- a/CRFModuleValidation/CRFMotionRecorder.swift
+++ b/CRFModuleValidation/CRFMotionRecorder.swift
@@ -38,12 +38,15 @@ import ResearchSuite
 public enum CRFMotionRecorderType : String, Codable {
     
     /// Raw accelerometer reading. `CMAccelerometerData` accelerometer.
+    /// - seealso: https://developer.apple.com/documentation/coremotion/getting_raw_accelerometer_events
     case accelerometer
     
     /// Raw gyroscope reading. `CMGyroData` rotationRate.
+    /// - seealso: https://developer.apple.com/documentation/coremotion/getting_raw_gyroscope_events
     case gyro
 
     /// Raw magnetometer reading. `CMMagnetometerData` magneticField.
+    /// - seealso: https://developer.apple.com/documentation/coremotion/cmmagnetometerdata
     case magnetometer
     
     /// Calculated orientation of the device using the gyro and magnetometer (if appropriate).
@@ -53,11 +56,15 @@ public enum CRFMotionRecorderType : String, Codable {
     /// - note: If the `magneticField` is included in the configuration's list of desired
     /// recorder types then the reference frame is `.xMagneticNorthZVertical`. Otherwise,
     /// the motion recorder will use `.xArbitraryZVertical`.
+    ///
+    /// - seealso: https://developer.apple.com/documentation/coremotion/getting_processed_device_motion_data
     case attitude
     
     /// Calculated vector for the direction of gravity in the coordinates of the device.
     ///
     /// This is included in the `CMDeviceMotion` data object.
+    ///
+    /// - seealso: https://developer.apple.com/documentation/coremotion/getting_processed_device_motion_data
     case gravity
     
     /// The magnetic field vector with respect to the device for devices with a magnetometer.
@@ -70,17 +77,23 @@ public enum CRFMotionRecorderType : String, Codable {
     /// - note: If this recorder type is included in the configuration, then the attitude
     /// reference frame will be set to `.xMagneticNorthZVertical`. Otherwise, the magnetic
     /// field vector will be returned as `{ 0, 0, 0 }`.
+    ///
+    /// - seealso: https://developer.apple.com/documentation/coremotion/getting_processed_device_motion_data
     case magneticField
     
     /// The rotation rate of the device for devices with a gyro.
     ///
     /// This is included in the `CMDeviceMotion` data object.
+    ///
+    /// - seealso: https://developer.apple.com/documentation/coremotion/getting_processed_device_motion_data
     case rotationRate
     
     /// Calculated vector for the user's acceleration in the coordinates of the device.
     /// This is the acceleration component after subtracting the gravity vector.
     ///
     /// This is included in the `CMDeviceMotion` data object.
+    ///
+    /// - seealso: https://developer.apple.com/documentation/coremotion/getting_processed_device_motion_data
     case userAcceleration
     
     public static func allTypes() -> [CRFMotionRecorderType] {

--- a/CRFModuleValidation/Cardio_Stair_Step.json
+++ b/CRFModuleValidation/Cardio_Stair_Step.json
@@ -94,11 +94,7 @@
                                                   "startStepIdentifier"     : "countdown",
                                                   "requiresBackgroundAudio" : true,
                                                   "recorderTypes"           : ["accelerometer",
-                                                                               "attitude",
-                                                                               "gravity",
-                                                                               "gyro",
-                                                                               "magnetometer",
-                                                                               "userAcceleration"]
+                                                                               "gyro"]
                                                   }
                                                   ],
                            "steps"          : [


### PR DESCRIPTION
The stair step task was failing to upload b/c the motion sensors put it over the edge of being too big.

This reduces the data that we are uploading in a couple of ways:

(1) The JPEG is compressed a wee bit more.
(2) Heart rate and stair step *only* collect raw readings of the accelerometer and gyro. The user acceleration and phone orientation can be calculated using these sensors.

Note: Confirmed with Meghasyam that raw readings are preferred if the choice is either/or.

FYI: @larssono @DwayneJengSage 