### PR TITLE
Force turning off the flash.

### DIFF
--- a/CRFModuleValidation/CRFHeartRateRecorder.swift
+++ b/CRFModuleValidation/CRFHeartRateRecorder.swift
@@ -154,6 +154,15 @@ public class CRFHeartRateRecorder : RSDSampleRecorder, CRFHeartRateProcessorDele
         
         updateStatus(to: .processingResults, error: nil)
         
+        // Force turning off the flash
+        if let captureDevice = _captureDevice {
+            do {
+                try captureDevice.lockForConfiguration()
+                captureDevice.torchMode = .auto
+                captureDevice.unlockForConfiguration()
+            } catch {}
+        }
+        
         // Append the camera settings
         if let settings = self.heartRateConfiguration?.cameraSettings {
             self.appendResults(settings)
@@ -196,8 +205,13 @@ public class CRFHeartRateRecorder : RSDSampleRecorder, CRFHeartRateProcessorDele
     private var _captureDevice: AVCaptureDevice?
     private var _videoPreviewLayer: AVCaptureVideoPreviewLayer?
     private var _loggingSamples: [CRFHeartRateSample] = []
+    private var _previousSettings: CRFCameraSettings?
     
     private var sampleProcessor: CRFHeartRateProcessor!
+    
+    private struct StoredDeviceSettings {
+        var lensPosition: Float
+    }
     
     deinit {
         _session?.stopRunning()

--- a/CRFModuleValidation/CRFHeartRateStepViewController.swift
+++ b/CRFModuleValidation/CRFHeartRateStepViewController.swift
@@ -116,14 +116,12 @@ public class CRFHeartRateStepViewController: RSDActiveStepViewController, RSDAsy
             self?._handleLensCoveredOnMainQueue(recorder.isCoveringLens)
         })
         
-        // If the user is trying for 10 seconds to cover the lens and it isn't recognized,
-        // then show a skip button.
-        let delay = DispatchTime.now() + .seconds(10)
+        // If the user is trying for 5 seconds to cover the lens and it isn't recognized,
+        // then just keep going. The result might be a 0 heart rate measurement, but we will
+        // still capture the data and can analyze it later.
+        let delay = DispatchTime.now() + .seconds(5)
         DispatchQueue.main.asyncAfter(deadline: delay) { [weak self] in
-            guard let strongSelf = self else { return }
-            if strongSelf.startUptime == nil {
-                strongSelf.skipButton.isHidden = false
-            }
+            self?._startCountdownIfNeeded()
         }
         
         // Create a motion recorder


### PR DESCRIPTION
From Job:
"First Pt (#201):
-  No issues downloading but the app killed his battery within the time it took to run the stair and 12-minute test (He started with 85%)
- HR capture would not turn off (likely battery drain cause).
"

I am guessing that "HR capture would not turn off" means the flash didn't automatically turn off?

I have had issues with the camera flash not always turning ON in response to the command to do so, so maybe?